### PR TITLE
update upstream-live

### DIFF
--- a/upstream-live/README.md
+++ b/upstream-live/README.md
@@ -1,6 +1,6 @@
 ## WARNING
 
-Files in this directory are from [the official repository](https://git.fedorahosted.org/cgit/spin-kickstarts.git/tree)
+Files in this directory are from [the official repository](https://pagure.io/fedora-kickstarts)
 
 Please do not edit them manually.
 
@@ -8,4 +8,4 @@ We should review and update them periodically to ensure the best performances fo
 
 ### Changes made
 
-The only change that was made was that we used the [non-rawhide repositories](https://git.fedorahosted.org/cgit/spin-kickstarts.git/tree/fedora-repo-not-rawhide.ks) instead of the the base [fedora-repo.ks](https://git.fedorahosted.org/cgit/spin-kickstarts.git/tree/fedora-repo.ks)
+The only change that was made was that we used the [non-rawhide repositories](https://pagure.io/fedora-kickstarts/blob/master/f/fedora-repo-not-rawhide.ks) instead of the base [fedora-repo.ks](https://pagure.io/fedora-kickstarts/blob/master/f/fedora-repo-not-rawhide.ks)

--- a/upstream-live/fedora-live-base.ks
+++ b/upstream-live/fedora-live-base.ks
@@ -17,8 +17,9 @@ xconfig --startxonboot
 zerombr
 clearpart --all
 part / --size 5120 --fstype ext4
-services --enabled=NetworkManager,ModemManager --disabled=network,sshd
+services --enabled=NetworkManager,ModemManager --disabled=sshd
 network --bootproto=dhcp --device=link --activate
+rootpw --lock --iscrypted locked
 shutdown
 
 %include fedora-repo.ks
@@ -72,7 +73,7 @@ cat > /etc/rc.d/init.d/livesys << EOF
 # chkconfig: 345 00 99
 # description: Init script for live image.
 ### BEGIN INIT INFO
-# X-Start-Before: display-manager
+# X-Start-Before: display-manager chronyd
 ### END INIT INFO
 
 . /etc/init.d/functions
@@ -173,7 +174,7 @@ if [ -n "\$configdone" ]; then
   exit 0
 fi
 
-# add fedora user with no passwd
+# add liveuser user with no passwd
 action "Adding live user" useradd \$USERADDARGS -c "Live System User" liveuser
 passwd -d liveuser > /dev/null
 usermod -aG wheel liveuser > /dev/null
@@ -214,7 +215,9 @@ touch /.liveimg-configured
 
 # add static hostname to work around xauth bug
 # https://bugzilla.redhat.com/show_bug.cgi?id=679486
-echo "localhost" > /etc/hostname
+# the hostname must be something else than 'localhost'
+# https://bugzilla.redhat.com/show_bug.cgi?id=1370222
+echo "localhost-live" > /etc/hostname
 
 EOF
 
@@ -321,6 +324,14 @@ echo 'File created by kickstart. See systemd-update-done.service(8).' \
 # See bug 1317709
 rm -f /boot/*-rescue*
 
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+/sbin/chkconfig network off
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
 %end
 
 
@@ -332,4 +343,5 @@ if [ "$(uname -i)" = "i386" -o "$(uname -i)" = "x86_64" ]; then
   if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
   cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
 fi
+
 %end

--- a/upstream-live/fedora-repo.ks
+++ b/upstream-live/fedora-repo.ks
@@ -1,2 +1,4 @@
-repo --name=fedora --mirrorlist=http://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
-repo --name=updates --mirrorlist=http://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
+repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f$releasever&arch=$basearch
+#repo --name=updates-testing --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-testing-f$releasever&arch=$basearch
+url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch


### PR DESCRIPTION
* `fedorahosted.org` was killed/moved to `pagure.io`
* use latest from there